### PR TITLE
Refactor repeated pattern in Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -102,7 +102,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus


### PR DESCRIPTION
**Reasons for making this change:**

Refactor repeated pattern: `.cache` is repeated twice but ideally, it should be mentioned only once in the `.gitignore` file and it will ignore all of the matching patterns.
